### PR TITLE
Locally host URL redirects

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,7 +441,8 @@
 			fetch("https://corsproxy.io/?" + encodeURIComponent(shortenerApiUrl)).then((response) => {
 				if(response.ok) {
 					response.text().then((text) => {
-						copyURLToClipboard(text);
+						let shortUrlCode = text.split("/").slice(-1);
+						copyURLToClipboard("https://diamond-dogg.github.io/spiral_generator_prealpha/short.html?" + shortUrlCode);
 					})
 				}
 				else {

--- a/short.html
+++ b/short.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<head>
+    <title>Spiral Viewer</title>
+	<link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+	<div class="warning-modal-full-page" id="warningModal-fullPage">
+		<div class="warning-modal">
+			<h1>Seizure Warning</h1>
+			<p>This website contains flashing images that might trigger seizures for people with photosensitive epilepsy.</p>
+			<p>If you have a history of epilepsy or seizures, please avoid this site like the plague.</p>
+			<button id="continueButton" onclick="hideWarning(); restartDisplay();">Continue</button>
+		</div>
+	</div>
+
+    <script type="text/javascript">
+        if(document.location.search.length < 2) {
+            window.location.href = "https://diamond-dogg.github.io/spiral_generator_prealpha/"
+        }
+        else {
+            // bounce to an "actual" link shortener, which then redirects to our viewer
+            window.location.href = "https://is.gd/" + document.location.search.substring(1);
+        }
+    </script>
+</body>


### PR DESCRIPTION
Currently, shortened URLs are provided via an admittedly sketchy-looking third-party service. We unfortunately cannot shorten the URLs ourselves while using Github free hosting (I think?), but we can host a trampoline on our site so that links aren't as sketchy.