### PR TITLE
Only redirect to our own site

### DIFF
--- a/short.html
+++ b/short.html
@@ -18,8 +18,25 @@
             window.location.href = "https://diamond-dogg.github.io/spiral_generator_prealpha/"
         }
         else {
-            // bounce to an "actual" link shortener, which then redirects to our viewer
-            window.location.href = "https://is.gd/" + document.location.search.substring(1);
+            let shortenedUrl = "https://is.gd/" + document.location.search.substring(1);
+            fetch("https://corsproxy.io/?" + encodeURIComponent(shortenedUrl)).then((response) => {
+                console.log(response.url.substring(0, 57));
+                if(response.ok) {
+                    if(response.url.length > 56 && response.url.substring(0, 57) == "https://diamond-dogg.github.io/spiral_generator_prealpha/") {
+                        window.location.href = response.url;
+                    }
+                    else {
+                        console.log("Invalid redirect found! Going back to home...");
+                        window.location.href = "https://diamond-dogg.github.io/spiral_generator_prealpha/";
+                    }
+                }
+                else {
+                    console.log("Redirect URL returned non-OK status code " + response.ok);
+                    window.location.href = "https://diamond-dogg.github.io/spiral_generator_prealpha/";
+                }
+            }).catch((error) => {
+                window.location.href = "https://diamond-dogg.github.io/spiral_generator_prealpha/"
+            });
         }
     </script>
 </body>


### PR DESCRIPTION
Avoid letting people use this site to sneakily redirect to other sites. This commit only accepts shortened URLs that redirect back to this site; otherwise, it sends people to the homepage.

Note that this wasn't _really_ a security issue (other link shorteners also let you redirect people to shady sites), but I still think it's worth being super safe here.