### PR TITLE
Render text + add background image

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,9 @@
 		<div><input type="range" id="motionBlur" min="0" max="5" step="0.01" value="0.75" class="slider"><label for="motionBlur">Motion Blur</label></div>
 		<div><input type="range" id="superSample" min="1" max="8" step="1" value="4" class="slider"><label for="superSample">Super Sampling Factor (Blur / AA quality)</label></div>
 		<div id="spacing"></div>
+		<div><input id="backgroundImageInput" type="text"><label for="backgroundImageInput"> Background Image</label></div>
+		<div><input type="range" id="backgroundImageOpacity" min="0" max="1" step="0.01" value="0.1" class="slider"><label for="backgroundImageOpacity"> Background Opacity</label></div>
+		<div id="spacing"></div>
 		<div><button onclick="randomizeSliders()">Randomize</button></div>
 		<div><button id="generateEditorBtn">Save Project to URL</button></div>
 		<div><button id="generateViewerBtn">Export Viewer to URL</button></div>
@@ -188,13 +191,12 @@
 		</div>
     </div>
 	
-	
-	
     <button class="fullscreen" id="fullscreenButton" onclick="toggleFullScreen()" style="display: none;">fullscreen</button>
     <canvas id="spiralCanvas"></canvas>
-	<script src="spiral.js"></script>
+    <image id="backgroundImage"></image>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="spiral.js"></script>
 	<script src="url-params.js"></script>
-	
 
 	<script>
 	function hideElement(elementID) {
@@ -683,5 +685,18 @@
 			window.open(url, '_blank');
 		}
 	</script>
+
+	<script>
+		document.getElementById("backgroundImageInput").addEventListener("input", (event) => {
+			var newSource = document.getElementById("backgroundImageInput").value;
+			document.getElementById("backgroundImage").src = newSource;
+		});
+
+		document.getElementById("backgroundImageOpacity").addEventListener("input", (event) => {
+			var newOpacity = document.getElementById("backgroundImageOpacity").value;
+			document.getElementById("backgroundImage").style.opacity = newOpacity;
+		});
+	</script>
+
 </body>
 </html>

--- a/render.html
+++ b/render.html
@@ -22,7 +22,8 @@
 	-->
 	<script type="text/javascript" src="lz-string.min.js"></script>
 </head>
-<body onload="resetInputs(); getUrlParams(); generateRenderSequence();">
+<!--timeout on generateRenderSequence so we have time to set the font size-->
+<body onload="resetInputs(); getUrlParams(); setTimeout(generateRenderSequence, 100);">
 	
 	
 	
@@ -189,6 +190,8 @@
 	
     <button class="fullscreen" id="fullscreenButton" onclick="toggleFullScreen()" style="display: none;">fullscreen</button>
     <canvas id="spiralCanvas"></canvas>
+	<canvas id="compositeCanvas"></canvas>
+    <image id="backgroundImage"></image>
 	<script src="spiral-record.js"></script>
 	<script src="url-params.js"></script>
 	
@@ -468,7 +471,20 @@
 
 		delayInput.addEventListener('input', () => {
 			delay = parseFloat(delayInput.value) * 1000;
-			updateDisplay();
+			/*
+				So this causes cursed timing bugs with the first few text iterations.
+				Essentially, when both subliminals and a delay are loaded from URL params,
+				updateDisplay() gets called twice in close succession.
+				This creates two competing updateDisplay() timeout loops for the first few loops.
+				It seems to fix itself eventually (I'm not sure how),
+				so it's not a huge problem in the web player.
+
+				However, when we're recording a spiral, the first few iterations are crucially important.
+				Having this delay in the renderer messes up the beginning of the spiral,
+				so as a stopgap measure, we just disable the update here.
+				It's only really useful when the user updates the delay, so there shouldn't be any fallout.
+			*/
+			// updateDisplay();
 		});
 
 		spaceInput.addEventListener('input', () => {

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ canvas {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    z-index: -1;
+    z-index: -2;
 }
 .fullscreen {
 	position: absolute;
@@ -71,6 +71,10 @@ select {
 
 
 
+#compositeCanvas {
+	display: none;
+}
+
 #hypnoText-container {
     position: fixed;
     top: 50%;
@@ -79,6 +83,7 @@ select {
     font-size: 10vh;
     text-align: center;
     color: rgba(255,255,255,0.5);
+	user-select: none;
 }
 
 #hypnoText-controls {
@@ -112,6 +117,20 @@ input[type="number"] {
 	background-color: rgba(0,0,0,0.5);
 	color: rgba(255,255,255,0.5);
 	height: 2vh;
+}
+
+#backgroundImageInput {
+    background-color: rgba(0,0,0,0.5);
+    color: rgba(255,255,255,0.5);
+    height: 2vh;
+}
+
+#backgroundImage {
+	width: 100%;
+	height: 100%;
+	opacity: 0.1;
+	z-index: -1;
+	object-fit: cover;
 }
 
 #hypnoText-randomize-button {

--- a/url-params.js
+++ b/url-params.js
@@ -30,6 +30,8 @@ const inputList = [
 	{ elementType: 'input', inputType: 'range', inputId: 'exp' },
 	{ elementType: 'select', inputType: 'select', inputId: 'hypnoText-blendMode-input'},
 	{ elementType: 'select', inputType: 'select', inputId: 'hypnoText-font-picker'},
+	{ elementType: 'input', inputType: 'text', inputId: 'backgroundImageInput'},
+	{ elementType: 'input', inputType: 'range', inputId: 'backgroundImageOpacity'},
 	{ elementType: 'input', inputType: 'range', inputId: 'pulseExp' },
 	{ elementType: 'input', inputType: 'number', inputId: 'forceLoop-actualNum' },
 	{ elementType: 'input', inputType: 'number', inputId: 'loopPeriod' },
@@ -156,6 +158,12 @@ function getUrlParams() {
             } else {
                 inputElement = document.querySelector(`${inputInfo.elementType}[type='${inputInfo.inputType}'][id='${inputInfo.inputId}']`);
             }
+
+			if (inputInfo.inputId == "backgroundImageInput") {
+				document.getElementById("backgroundImage").src = decodeURIComponent(value);
+			} else if (inputInfo.inputId == "backgroundImageOpacity") {
+				document.getElementById("backgroundImage").style.opacity = decodeURIComponent(value);
+			}
 
             if (inputElement) {
                 let decodedValue = decodeURIComponent(value);

--- a/viewer.html
+++ b/viewer.html
@@ -193,13 +193,12 @@
 		</div>
     </div>
 	
-	
-	
     <button class="fullscreen" id="fullscreenButton" onclick="toggleFullScreen()">fullscreen</button>
     <canvas id="spiralCanvas"></canvas>
-	<script src="spiral.js"></script>
+    <image id="backgroundImage"></image>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="spiral.js"></script>
 	<script src="url-params.js"></script>
-	
 
 	<script>
 	function hideElement(elementID) {


### PR DESCRIPTION
Renders text when saving to GIF. Also adds a background image with adjustable opacity.

This is a moderate change to how rendering works. Instead of capturing the WebGL canvas directly, we keep an offscreen 2D canvas which the spiral, the text, and the image are all composited onto. As such, there may very well be bugs that I didn't catch. Please do let me know when things get weird, and I'll try to fix them.

There is a known semi-issue where parts of text flicker with certain spirals at certain resolutions. To the best of my knowledge, this is a problem with the GIF format rather than with anything we're doing. When these same spirals are rendered at higher resolutions, the issue goes away.

Let me know if there's anything you want me to change, or if anything breaks. I've tested this somewhat thoroughly on desktop Chrome, but there's no telling how it might act in other contexts.