### PR TITLE
Fix for renders without background images

### DIFF
--- a/url-params.js
+++ b/url-params.js
@@ -160,7 +160,11 @@ function getUrlParams() {
             }
 
 			if (inputInfo.inputId == "backgroundImageInput") {
-				document.getElementById("backgroundImage").src = decodeURIComponent(value);
+				let imageSource = decodeURIComponent(value);
+				if(imageSource) {
+					// Avoid setting the source to an empty string, which leads to thoroughly haunted problems later
+					document.getElementById("backgroundImage").src = imageSource;
+				}
 			} else if (inputInfo.inputId == "backgroundImageOpacity") {
 				document.getElementById("backgroundImage").style.opacity = decodeURIComponent(value);
 			}


### PR DESCRIPTION
Fixes spiral rendering without background images.

The issue was a confusing edge case in HTML image elements. Currently, if a spiral has a background image, we have to wait for that background image to load before rendering. This is done by attaching the render method to the `onload` of the background image. However, if the background image has an invalid source, the `onload` method will never fire, and thus rendering will never start.

This is a partial fix that should work for now. It doesn't actually fix the root of the problem -- invalid URLs cause rendering to fail -- but it stops us from trying to fetch a background image on a spiral without one.
