### PR TITLE
Fix Discord images in recording

### DIFF
--- a/spiral-record.js
+++ b/spiral-record.js
@@ -451,7 +451,9 @@ function generateRenderSequence() {
     // Do some thoroughly cursed shit to avoid CORS burning down our house, as per usual
     backgroundImage.crossOrigin="anonymous";
     if(backgroundImage.src) {
-        backgroundImage.src = "https://corsproxy.io/?" + encodeURIComponent(backgroundImage.src)
+	// Disable CORS proxy for now, since it breaks under unknown conditions
+	// One of these conditions is loading Discord images, which sucks, because that's where our hypno nonsense is
+        // backgroundImage.src = "https://corsproxy.io/?" + encodeURIComponent(backgroundImage.src)
 
         // ensure the background image loads before we start recording
         backgroundImage.onload = startRendering;


### PR DESCRIPTION
...by disabling the CORS proxy for background images.

The existing proxy breaks on Discord images. Whether this is the proxy's fault or Discord's fault is impossible to say, but since loading from Discord is more important than loading from sites that haven't been updated since 2005, we will work with this for now.

In the long term, a better solution would be to fetch the image directly first (as we're now doing), and then fall back to a CORS proxy if we get the appropriate error.