### PR TITLE
Image stretching support, various bugfixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 		However, a world with hyperactive CORB is not an ideal world.
 	-->
 	<script type="text/javascript" src="lz-string.min.js"></script>
+	<script type="text/javascript" src="utils.js"></script>
 </head>
 <body onload="resetInputs(); getUrlParams();">
 	<div class="warning-modal-full-page" id="warningModal-fullPage">
@@ -37,6 +38,7 @@
 		<button id="button-credits" menu="credits" class="menu-toggle" type="button_toggle">Credits</button>
 	</div>
 	
+	<button id="button-hide-ui" onclick="utils_sendHideUI()">Toggle Hide UI (H)</button>
 
 	
 	<div id="render-settings-menu" style="display: none">
@@ -177,6 +179,8 @@
 		<div id="spacing"></div>
 		<div><input id="backgroundImageInput" type="text"><label for="backgroundImageInput"> Background Image</label></div>
 		<div><input type="range" id="backgroundImageOpacity" min="0" max="1" step="0.01" value="0.1" class="slider sliderNumPair"><label> </label><input type="text" value="0.1" class="sliderNumPair" id="backgroundImageOpacity-num"><label for="backgroundImageOpacity"> Background Opacity</label></div>
+		<div id="spacing"></div>
+		<div><button id="backgroundImageStretchButton" onclick="util_toggleUseFixedSizeBackgroundImage()">Turn Off Background Image Stretching</button></div>
 	</div>
 	
 	<div id="pend-menu" style="display: none">
@@ -267,7 +271,15 @@
 	
 	
 	<script>
-		document.body.onkeydown = function(e) {
+		document.body.addEventListener("keydown", function(e) {
+			// Don't interefere with people typing in text areas
+			let activeElement = document.activeElement
+			console.log("nodename: " + activeElement.nodeName);
+			console.log("type: " + activeElement.getAttribute("type"));
+			if (activeElement.nodeName == "TEXTAREA" || (activeElement.nodeName == "INPUT" && activeElement.getAttribute("type") == "text")) {
+				return;
+			}
+
 			if (e.key == 'h' || e.key == 'H') {
 				const ids = [
 					'full-page'
@@ -283,7 +295,10 @@
 					}
 				});
 			}
-		};
+			else  if (e.key === "r" || e.key === "R"){
+				randomizeSliders();
+		  	}
+		});
 	</script>
 	
 	
@@ -726,12 +741,6 @@
             });
         }
 		
-		document.addEventListener("keydown", function(event) {
-		  if (event.key === "r" || event.key === "R"){
-			randomizeSliders();
-		  }
-		});
-		
 		function randomizeSliders() {
 		  document.querySelectorAll("input[type='range']").forEach(function (slider) {
 			if (
@@ -865,8 +874,20 @@
 
 	<script>
 		document.getElementById("backgroundImageInput").addEventListener("input", (event) => {
+			let backgroundImage = document.getElementById("backgroundImage");
+
 			var newSource = document.getElementById("backgroundImageInput").value;
-			document.getElementById("backgroundImage").src = newSource;
+			if(newSource) {
+				backgroundImage.src = newSource;
+				backgroundImage.style.display = "block";
+			}
+			else {
+				backgroundImage.removeAttribute("src");
+				backgroundImage.style.display = "none";
+
+				// Prevent fixed-image resizing from sticking around after the background image is removed.
+        		document.getElementById("spiralCanvas").style = "";
+			}
 		});
 
 		document.getElementById("backgroundImageOpacity").addEventListener("input", (event) => {

--- a/render.html
+++ b/render.html
@@ -24,7 +24,7 @@
 	<script type="text/javascript" src="lz-string.min.js"></script>
 </head>
 <!--timeout on generateRenderSequence so we have time to set the font size-->
-<body onload="resetInputs(); getUrlParams(); setTimeout(generateRenderSequence, 100);">
+<body onload="resetInputs(); getUrlParams(true); setTimeout(generateRenderSequence, 100);">
 
 
 

--- a/spiral-record.js
+++ b/spiral-record.js
@@ -419,7 +419,7 @@ function composite() {
     // Step 3: if there's a background image, draw it at its given opacity
     if(backgroundImage) {
         compositeCanvasContext.globalAlpha = document.getElementById("backgroundImage").style.opacity;
-		compositeCanvasContext.drawImage(backgroundImage, 0, 0, renderWidth, renderHeight);
+	compositeCanvasContext.drawImage(backgroundImage, 0, 0, renderWidth, renderHeight);
     }
 
     // Step 4 (the fun part): draw the text
@@ -473,7 +473,7 @@ function recRender(time) {
 
     if (recFrameCount < maxFrames) {
         composite();
-		capturer.capture(compositeCanvas);
+	capturer.capture(compositeCanvas);
         recFrameCount++;
     } else if (recFrameCount === maxFrames) {
         capturer.stop();

--- a/spiral-record.js
+++ b/spiral-record.js
@@ -419,7 +419,7 @@ function composite() {
     // Step 3: if there's a background image, draw it at its given opacity
     if(backgroundImage) {
         compositeCanvasContext.globalAlpha = document.getElementById("backgroundImage").style.opacity;
-	compositeCanvasContext.drawImage(backgroundImage, 0, 0, renderWidth, renderHeight);
+		compositeCanvasContext.drawImage(backgroundImage, 0, 0, renderWidth, renderHeight);
     }
 
     // Step 4 (the fun part): draw the text
@@ -473,7 +473,7 @@ function recRender(time) {
 
     if (recFrameCount < maxFrames) {
         composite();
-	capturer.capture(compositeCanvas);
+		capturer.capture(compositeCanvas);
         recFrameCount++;
     } else if (recFrameCount === maxFrames) {
         capturer.stop();

--- a/style.css
+++ b/style.css
@@ -144,6 +144,7 @@ input[type="number"] {
 	opacity: 0.1;
 	z-index: -1;
 	object-fit: cover;
+	margin: auto;
 }
 
 #hypnoText-randomize-button {
@@ -154,6 +155,12 @@ input[type="number"] {
 button[type="button_toggle"].active {
 	color: white;
 	text-shadow: 0 0 5px rgba(255,255,255,0.5);
+}
+
+#button-hide-ui {
+	position: absolute;
+	top: 0;
+	right: 0;
 }
 
 #looping-controls {

--- a/url-params.js
+++ b/url-params.js
@@ -47,6 +47,7 @@ const inputList = [
 	{ elementType: 'input', inputType: 'range', inputId: 'pend-angle' },
 	{ elementType: 'input', inputType: 'range', inputId: 'pend-length' },
 	{ elementType: 'input', inputType: 'range', inputId: 'pend-size' },
+	{ elementType: 'button', inputType: 'button_toggle', inputId: 'backgroundImageStretchButton' },
 ];
 
 function generateURL(urlType) {
@@ -143,7 +144,7 @@ function onFontPickerChange(inputElement, value) {
 
 
 
-function getUrlParams() {
+function getUrlParams(isRendering = false) {
 	let urlParams = window.location.search;
 	if (!urlParams.includes('&')) {
 		urlParams = LZString.decompressFromEncodedURIComponent(urlParams.substring(1));
@@ -154,6 +155,7 @@ function getUrlParams() {
 
     console.log(urlParams.toString());
 
+	var backgroundImage = document.getElementById("backgroundImage")
     values.forEach((value, index) => {
         let inputInfo = inputList[index];
         if (inputInfo) {
@@ -168,10 +170,18 @@ function getUrlParams() {
 				let imageSource = decodeURIComponent(value);
 				if(imageSource) {
 					// Avoid setting the source to an empty string, which leads to thoroughly haunted problems later
-					document.getElementById("backgroundImage").src = imageSource;
+					backgroundImage.src = imageSource;
 				}
 			} else if (inputInfo.inputId == "backgroundImageOpacity") {
-				document.getElementById("backgroundImage").style.opacity = decodeURIComponent(value);
+				backgroundImage.style.opacity = decodeURIComponent(value);
+			}
+			else if (inputInfo.inputId == "backgroundImageStretchButton" && !isRendering) {
+				// Make sure not to stretch the image when rendering; it's handled automatically.
+				if(decodeURIComponent(value) == "true") {
+					backgroundImage.onload = () => {
+						util_toggleUseFixedSizeBackgroundImage();
+					}
+				}
 			}
 
             if (inputElement) {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,62 @@
+var util_usingFixedBackgroundImageSize = false;
+
+function util_SetFixedSizeBackgroundImage() {
+    if(!util_usingFixedBackgroundImageSize) {
+        return;
+    }
+
+    let backgroundImage = document.getElementById("backgroundImage");
+    let canvas = document.getElementById("spiralCanvas");
+
+    // We want to stretch the image in one direction until it hits the boundary of the window.
+    // To do that, first we figure out which direction we'd hit the window in first:
+    let verticalScaleFactor = window.innerHeight / backgroundImage.naturalHeight;
+    let horizontalScaleFactor = window.innerWidth / backgroundImage.naturalWidth;
+
+    let newHeight;
+    let newWidth;
+    if(Math.abs(1 - verticalScaleFactor) > Math.abs(1 - horizontalScaleFactor)) {
+        newHeight = backgroundImage.naturalHeight * horizontalScaleFactor; 
+        newWidth = backgroundImage.naturalWidth * horizontalScaleFactor;
+    }
+    else {
+        newHeight = backgroundImage.naturalHeight * verticalScaleFactor; 
+        newWidth = backgroundImage.naturalWidth * verticalScaleFactor;
+    }
+
+    backgroundImage.style.width = newWidth + "px";
+    backgroundImage.style.height = newHeight + "px";
+    canvas.style.width = newWidth + "px";
+    canvas.style.height = newHeight + "px";
+}
+
+function util_toggleUseFixedSizeBackgroundImage() {
+    let button = document.getElementById("backgroundImageStretchButton");
+    if(util_usingFixedBackgroundImageSize) {
+        backgroundImage.style.width = "";
+        backgroundImage.style.height = "";
+        canvas.style.width = "";
+        canvas.style.height = "";
+
+        util_usingFixedBackgroundImageSize = !util_usingFixedBackgroundImageSize;
+        
+        button.classList.remove("active");
+        button.innerText = "Turn Off Background Image Stretching";
+    }
+    else {
+        // set before calling setFixedSizeBackgroundImage so it actually works
+        util_usingFixedBackgroundImageSize = !util_usingFixedBackgroundImageSize;
+
+        util_SetFixedSizeBackgroundImage()
+
+        button.classList.add("active");
+        button.innerText = "Turn On Background Image Stretching";
+    }
+
+}
+
+function utils_sendHideUI() {
+    document.body.dispatchEvent(new KeyboardEvent("keydown", { "key": "H" }));
+}
+
+window.addEventListener("resize", util_SetFixedSizeBackgroundImage);

--- a/viewer.html
+++ b/viewer.html
@@ -22,6 +22,7 @@
 		However, a world with hyperactive CORB is not an ideal world.
 	-->
 	<script type="text/javascript" src="lz-string.min.js"></script>
+	<script type="text/javascript" src="utils.js"></script>
 </head>
 <body onload="resetInputs(); getUrlParams();">
 	<div class="warning-modal-full-page" id="warningModal-fullPage">
@@ -182,6 +183,8 @@
 		<div><input type="range" id="backgroundImageOpacity" min="0" max="1" step="0.01" value="0.1" class="slider sliderNumPair"><label> </label><input type="text" value="0.1" class="sliderNumPair" id="backgroundImageOpacity-num"><label for="backgroundImageOpacity"> Background Opacity</label></div>
 		<div id="spacing"></div>
 		<div><button onclick="randomizeSliders()">Randomize</button></div>
+		<div id="spacing"></div>
+		<div><button id="backgroundImageStretchButton" onclick="util_toggleUseFixedSizeBackgroundImage()">Turn Off Background Image Stretching</button></div>
 	</div>
 	
 	<div id="pend-menu" style="display: none">


### PR DESCRIPTION
Adds the ability to toggle whether a background image is stretched to fill the screen or kept at its current resolution. Also adds a button to toggle hiding the UI and indicate the existence of that hotkey.

Also, a few bugfixes:
- Re-implement hotkeys so users can type H and R in text boxes again
- Removed an annoying "missing file" icon when background images were not present