### PR TITLE
fix CORS error

### DIFF
--- a/short.html
+++ b/short.html
@@ -11,7 +11,7 @@
         else {
             // bounce to an "actual" link shortener, which then redirects to our viewer
             let shortenedUrl = "https://wheel.to/" + document.location.search.substring(1);
-            fetch(shortenedUrl).then((response) => {
+            fetch("https://corsproxy.io/?" + encodeURIComponent(shortenedUrl)).then((response) => {
                 console.log(response.url.substring(0, 57));
                 if(response.ok) {
                     if(response.url.length > 56 && response.url.substring(0, 57) == "https://diamond-dogg.github.io/spiral_generator_prealpha/") {


### PR DESCRIPTION
This shortener doesn't require CORS on the initial request, but does seem to require it on the shortened link fetch. Adjust accordingly.