### PR TITLE
Fail gracefully when link shortening fails

### DIFF
--- a/url-params.js
+++ b/url-params.js
@@ -94,23 +94,29 @@ function generateURL(urlType) {
 		var copyURL = openRenderURL;
 	}
 	
-	fetch("https://api.wheel.to/v1/link/", {
-		method: "POST",
-		body: JSON.stringify({
-			long_url: url
-		})
-	}).then((response) => {
-		if(response.ok) {
-			response.text().then((text) => {
-				var jsonResponse = JSON.parse(text);
-				copyURL("https://diamond-dogg.github.io/spiral_generator_prealpha/short.html?" + jsonResponse.id);
+	try {
+		fetch("https://api.wheel.to/v1/link/", {
+			method: "POST",
+			body: JSON.stringify({
+				long_url: url
 			})
-		}
-		else {
-			console.log("Link shortener returned non-OK status: " + response.status);
-			copyURL(url);
-		}
-	})
+		}).then((response) => {
+			if(response.ok) {
+				response.text().then((text) => {
+					var jsonResponse = JSON.parse(text);
+					copyURL("https://diamond-dogg.github.io/spiral_generator_prealpha/short.html?" + jsonResponse.id);
+				})
+			}
+			else {
+				console.log("Link shortener returned non-OK status: " + response.status);
+				copyURL(url);
+			}
+		})
+	}
+	catch (err) {
+		console.log("Error when fetching from link shortener: " + err);
+		copyURL(url);
+	}
 }
 
 


### PR DESCRIPTION
Currently, if an error happens while we're fetching the short link, no link is copied at all. This prevents users from saving spirals.

To fix this, we wrap the fetch in a try/catch and copy the long link if something goes haywire.
(i haven't actually tested this, because i can't get the thing to fail for me, but it shouuuld work^tm)